### PR TITLE
Make PHPUnit write .coverage.xml and send it to coveralls

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -49,7 +49,7 @@ jobs:
       run: composer run-script test
 
     - name: Upload coverage results to Coveralls
-      if: matrix.php-versions == '8.1'
+      if: matrix.php-version == '8.1'
       continue-on-error: true  # do not fail on Coveralls uploads
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,3 +47,12 @@ jobs:
 
     - name: Run test suite
       run: composer run-script test
+
+    - name: Upload coverage results to Coveralls
+      if: matrix.php-versions == '8.1'
+      continue-on-error: true  # do not fail on Coveralls uploads
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        composer global require php-coveralls/php-coveralls
+        php-coveralls --coverage_clover=.coverage.xml --json_path=/tmp/coverage.json -v

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 .phpunit.cache
 .phpunit.result.cache
 _coverage
+.coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 monolog-utils
-[![Latest Stable Version](http://poser.pugx.org/macbre/monolog-utils/v)](https://packagist.org/packages/macbre/monolog-utils)
 ===============
+
+[![Latest Stable Version](http://poser.pugx.org/macbre/monolog-utils/v)](https://packagist.org/packages/macbre/monolog-utils)
+[![Coverage Status](https://coveralls.io/repos/github/macbre/monolog-utils/badge.svg?branch=master)](https://coveralls.io/github/macbre/monolog-utils?branch=master)
 
 Additional formatters and processors for Monolog 3.x. This package requires PHP 8.1+.
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "scripts": {
-        "test": "XDEBUG_MODE=coverage phpunit --coverage-text --coverage-html _coverage"
+        "test": "XDEBUG_MODE=coverage phpunit --coverage-text --coverage-clover=.coverage.xml --coverage-html _coverage"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0"


### PR DESCRIPTION
```
Using version ^2.5 for php-coveralls/php-coveralls
Load coverage clover log:
  - /home/runner/work/monolog-utils/monolog-utils/.coverage.xml
Found 3 source files:
  - 100.00% src/Macbre/Formatters/JsonFormatter.php
  -  [95](https://github.com/macbre/monolog-utils/actions/runs/4721630823/jobs/8375132697#step:8:96).65% src/Macbre/Processors/ExceptionProcessor.php
  - 100.00% src/Macbre/Processors/RequestIdProcessor.php
Coverage:  [97](https://github.com/macbre/monolog-utils/actions/runs/4721630823/jobs/8375132697#step:8:98).67% (42/43)
Collect git info
Read environment variables
Dump submitting json file: /tmp/coverage.json
File size: 5.34 kB
Submitting to https://coveralls.io/api/v1/jobs
```